### PR TITLE
QUICKFIX: don't stop sending the balance emails when an email cannot be sent

### DIFF
--- a/ingifet.py
+++ b/ingifet.py
@@ -224,8 +224,10 @@ class mail:
                                solde = float2str(u.balance), 
                                prenom = u.firstname, 
                                nom = u.lastname)
-
-            web.sendmail(settings.MAIL_ADDRESS, u.email, 'Your INGI cafetaria balance', body)
+            try:
+                web.sendmail(settings.MAIL_ADDRESS, u.email, 'Your INGI cafetaria balance', body)
+            except:
+                pass
 
         if userside:
             return render_no_layout.consume('BALANCE', u)


### PR DESCRIPTION
When sending the "Your INGI cafetaria balance", the loop will stop as soon as one sendmail() call fails.

Quick fix: catching the exception and pass to continue the loop.

TODO: keep a list of the fails to be displayed at the end of the loop.